### PR TITLE
Allow an empty string ("") or boolean false to disable of indentation

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4132,6 +4132,9 @@ namespace ts {
             }
             singleLevel = "".padStart(indentation, " ");
         }
+        else if (indentation === false) {
+            singleLevel = "";
+        }
         else {
             singleLevel = "    ";
         }
@@ -4158,7 +4161,7 @@ namespace ts {
         let lineCount: number;
         let linePos: number;
         let hasTrailingComment = false;
-        if (indentation || indentation === 0) {
+        if (indentation !== undefined) {
             setIndentString(indentation);
         }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4049,6 +4049,7 @@ declare namespace ts {
         newLine?: NewLineKind;
         omitTrailingSemicolon?: boolean;
         noEmitHelpers?: boolean;
+        indentation?: string | number;
     }
     export interface GetEffectiveTypeRootsHost {
         directoryExists?(directoryName: string): boolean;


### PR DESCRIPTION
Also updates the api reference to include the PrinterOptions.indentation property

This is a continuation of the pull request https://github.com/microsoft/TypeScript/pull/50855 .
